### PR TITLE
correct proposal

### DIFF
--- a/mst.py
+++ b/mst.py
@@ -131,7 +131,7 @@ def reweighting(weights: np.array):
 
 # weights[head][dep] =  weight of head ---> dep (head entering dep)
 def fast_parse(weights: np.array, one_root: bool) -> np.array:
-    proposal = weights.argmax(axis=1)
+    proposal = weights.argmax(axis=0)
     root_count = np.count_nonzero(proposal[1:] == 0)
 
     if is_tree(proposal) and (not one_root or root_count == 1):


### PR DESCRIPTION
the convention of head -> dep is reverse

a counter example input that yields incorrect output:
w = np.array([[1, 0, 1],
                  [7, 6, 5],
                  [6, 7, 1]]).astype(np.float)

output: [-1  0  1]   (tree weight = 5)
expected [-1 2 0]   (tree weight = 8)